### PR TITLE
Content parsing: updated forbidden words

### DIFF
--- a/module_reviewer.py
+++ b/module_reviewer.py
@@ -239,12 +239,12 @@ def check_forbidden_words(line, report, prefix=None):
     # 'forbidden word': 'alternative'
     FORBIDDEN_WORDS = {
         'via ': 'by/through',
-        'e.g': 'for example',
+        'e.g.': 'for example',
         'etc.': 'and so on',
         'etc,': 'and so on',
         'etc)': 'and so on',
         'etc\n': 'and so on',
-        'i.e': 'in other words',
+        'i.e.': 'in other words',
         ' vs ': 'rather than/against',
         'vs ': 'rather than/against',
         ' vs)': 'rather than/against',


### PR DESCRIPTION
In the `module_reviewer.py` module, the method [`check_forbidden_words` ](https://github.com/Andersson007/ansible_reviewer/blob/main/module_reviewer.py#L237)has string matching done for "e.g" and "i.e" which should have been "e.g." and "i.e." respectively, because in many of the ansible modules such statements are getting caught by your module as like below:
![image](https://user-images.githubusercontent.com/69839943/150068567-87a63290-1354-49cd-8f35-d4b21cf530c2.png)
Hence such instances must be ignored.

